### PR TITLE
Changing the amlight kytos docker image to use docker hub

### DIFF
--- a/examples/amlight-topology/README
+++ b/examples/amlight-topology/README
@@ -12,13 +12,13 @@ cd /tmp
 git clone https://github.com/amlight/amlight-sdx
 
 # AmLight
-docker run -d --name amlight -p 6653:6653 -p 8181:8181 -v $(pwd)/amlight-sdx:/amlight-sdx gitlab.ampath.net:5000/amlight/kytos-prod:testing
+docker run -d --name amlight -p 6653:6653 -p 8181:8181 -v $(pwd)/amlight-sdx:/amlight-sdx amlight/kytos-prod:latest
 
 # SAX
-docker run -d --name sax -p 6654:6653 -p 8182:8181 -v $(pwd)/amlight-sdx:/amlight-sdx gitlab.ampath.net:5000/amlight/kytos-prod:testing
+docker run -d --name sax -p 6654:6653 -p 8182:8181 -v $(pwd)/amlight-sdx:/amlight-sdx amlight/kytos-prod:latest
 
 # TENET
-docker run -d --name tenet -p 6655:6653 -p 8183:8181 -v $(pwd)/amlight-sdx:/amlight-sdx gitlab.ampath.net:5000/amlight/kytos-prod:testing
+docker run -d --name tenet -p 6655:6653 -p 8183:8181 -v $(pwd)/amlight-sdx:/amlight-sdx amlight/kytos-prod:latest
 
 INSTALL sdx napp
 docker exec -it tenet bash


### PR DESCRIPTION
### Description of the change

This PR changes the AmLight Kytos docker image to use the one available at the docker hub, instead of Amlight's internal docker registry. Tests were run to make sure the documentation remains consistent.

### Release Nodes

N/A